### PR TITLE
fix: call hide() on settings tabs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -194,6 +194,7 @@ export default class SettingsSearch extends Plugin {
             this.addResourceToCache(resource);
         }
         tab.containerEl.detach();
+        tab.hide();
     }
 
     patchSettings() {


### PR DESCRIPTION
Call `tab.hide()` so that you trigger plugin's `hide` logic which is occasionally used to unload components.