### PR TITLE
Show the setting name in the search results

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -167,7 +167,7 @@ export default class SettingsSearch extends Plugin {
                 el.createSpan({ text: resource.text });
             });
         } else {
-            name = resource.name;
+            name = resource.text;
         }
         const setting = new Setting(createDiv())
             .setName(name)


### PR DESCRIPTION
Great plugin - however when using it I noticed that the setting name wasn't showing, instead the setting section name was repeated, leading to some confusion. See screenshots:

Before:

![obsdian-setting-search-before](https://user-images.githubusercontent.com/5101742/214687544-1f1f7538-4400-4f34-a994-bd7cee21f4b5.png)

After:

![obsdian-setting-search-after](https://user-images.githubusercontent.com/5101742/214687598-d96d4e80-bc33-47a1-a4d9-6f3b16be9cac.png)



